### PR TITLE
fix:typo

### DIFF
--- a/lib/core/create_project/auth_handler.dart
+++ b/lib/core/create_project/auth_handler.dart
@@ -80,7 +80,7 @@ class AuthService extends ChangeNotifier {
   init() {
     client
         .setEndpoint('replace_with_your_endpoint')
-        .setProject('replace_with_project_name')
+        .setProject('replace_with_project_id')
         .setSelfSigned();
     account = Account(client);
   }


### PR DESCRIPTION
changed `'replace_with_project_name'` to `'replace_with_project_id'`

This PR fixes #70 